### PR TITLE
EESA-#1 Bulletin crash after selecting tag filter 

### DIFF
--- a/src/components/Bulletin.js
+++ b/src/components/Bulletin.js
@@ -87,6 +87,7 @@ export default class Bulletin extends React.Component {
 
   render() {
     const data = this.props.data
+    console.log(data)
     if (this.state.filter_tag.length > 0) {
       datas = datas.filter((item) => {
         const tmp = item.tag.filter((value) =>


### PR DESCRIPTION
### What is this PR for?
I have already fix the bug

### What type of PR is it?
Bug Fix

### Todos
* [x] try to locate where the bug happened
* [  ] resolve

### What is the Github issue?
#1 

### How should this be tested?
Steps to reproduce the behavior:

1. Go to "消息公告"
2. Click on select
3. Click on 公告
4. No error

### Screenshots (if appropriate)
Not yet

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
